### PR TITLE
Json body short circuit pass

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@ Unreleased
 ----------
 
 - Remove support for python 3.2.
+- Change json-body matcher to pass when the recorded request has the same
+  content type as the issued request, and the content type is not json.
 
 0.3.0 - 2016-04-16
 ------------------

--- a/betamax_matchers/json_body.py
+++ b/betamax_matchers/json_body.py
@@ -18,10 +18,15 @@ class JSONBodyMatcher(BaseMatcher):
         """Determine if the JSON encoded bodies match."""
         recorded = util.deserialize_prepared_request(recorded_request)
 
-        # If neither of them have the right Content-Type set, return False
-        if not (is_json(request.headers.get('Content-Type')) and
-                is_json(recorded.headers.get('Content-Type'))):
+        recorded_type = recorded.headers.get('Content-Type')
+        request_type = request.headers.get('Content-Type')
+        # Short circuit fail when the content types do not match
+        if recorded_type != request_type:
             return False
+        # Short circuit pass when the content type is not json
+        # This permits other matchers to do the matching on this body.
+        if not is_json(recorded_type):
+            return True
 
         request_json = json.loads(request.body) if request.body else None
 

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,9 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: Implementation :: CPython',
     ]
 )

--- a/tests/test_json_body.py
+++ b/tests/test_json_body.py
@@ -57,7 +57,7 @@ def test_short_circuit_based_on_content_type(eq_request, recorded_request,
     assert matcher.match(eq_request, recorded_request) is False
 
     del recorded_request['headers']['Content-Type']
-    assert matcher.match(eq_request, recorded_request) is False
+    assert matcher.match(eq_request, recorded_request) is True
 
     eq_request.headers['Content-Type'] = 'application/json'
     assert matcher.match(eq_request, recorded_request) is False


### PR DESCRIPTION
I am creating this pull request because I have a cassette that has a mix of urlencoded request bodies, and json request bodies.

With this modification I can use the jsonbody matcher in combination with another similarly permissive body matcher. I will likely need to make a similar PR for the URLEncodedBodyMatcher so that I can use both. 
